### PR TITLE
Add .gitignore for various binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .DS_Store
 ._.DS_Store
 .*.un~
-*.pdf
-*.ppt
 *.mp4
 *.mov
+*.ppt
 *.pptx
+*.pdf
+*.tar.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .DS_Store
+._.DS_Store
 .*.un~
+*.pdf
+*.ppt
+*.mp4
+*.mov
+*.pptx

--- a/README.md
+++ b/README.md
@@ -1,22 +1,5 @@
 Presentations from the OME Team
 ===============================
 
-Slide shows for OME and OMERO based on https://github.com/hakimel/reveal.js
-
- * [2013/fs-workshop-paris](http://ome.github.io/presentations/2013/fs-workshop-paris)
- * [2014/figure_march_11](http://ome.github.io/presentations/2014/figure_march_11)
- * [2014/fs-workshop-paris](http://ome.github.io/presentations/2014/fs-workshop-paris)
- * [2014/paris_web_workshop](http://ome.github.io/presentations/2014/paris_web_workshop)
- * [2014/sussex](http://ome.github.io/presentations/2014/sussex)
- * [2014/technique_tapas_nov_5](http://ome.github.io/presentations/2014/technique_tapas_nov_5)
- * [2015/Omero-Web-Workshop](http://ome.github.io/presentations/2015/Omero-Web-Workshop)
- * [2015/Rois-Tuesday-18th-August](http://ome.github.io/presentations/2015/Rois-Tuesday-18th-August)
- * [2015/analysis-workshop-paris](http://ome.github.io/presentations/2015/analysis-workshop-paris)
- * [2015/bioformats-overview-imagej-conf](http://ome.github.io/presentations/2015/bioformats-overview-imagej-conf)
- * [2015/bioformats-overview-paris](http://ome.github.io/presentations/2015/bioformats-overview-paris)
- * [2015/data-repo-15-sep-15](http://ome.github.io/presentations/2015/data-repo-15-sep-15)
- * [2015/decoupling_july_15](http://ome.github.io/presentations/2015/decoupling_july_15)
- * [2015/hdf-workshop-paris](http://ome.github.io/presentations/2015/hdf-workshop-paris)
- * [2015/import-workshop-paris](http://ome.github.io/presentations/2015/import-workshop-paris)
- * [2015/public-repository-workshop-paris](http://ome.github.io/presentations/2015/public-repository-workshop-paris)
- * [2016/Web-Planning-Jan-2016](http://ome.github.io/presentations/2016/Web-Planning-Jan-2016)
+Slide shows for OME based on https://github.com/hakimel/reveal.js available
+under http://downloads.openmicroscopy.org/presentations/ 


### PR DESCRIPTION
In order to streamline and reconcile the deployment of our reveal-js based presentations, this PR adds a few other binary files used for presentation material to the top-level .gitignore.

/cc @jburel @joshmoore 