### PR TITLE
Add structure for the content of the 2018 Users meeeting

### DIFF
--- a/2018/Users-Meeting/Lightning-Talks/readme.txt
+++ b/2018/Users-Meeting/Lightning-Talks/readme.txt
@@ -1,0 +1,2 @@
+Slides for the lightning talks of the 2018 OME Users Meeting
+https://www.openmicroscopy.org/events/13th-annual-users-meeting-2018.html

--- a/2018/Users-Meeting/Talks/readme.txt
+++ b/2018/Users-Meeting/Talks/readme.txt
@@ -1,0 +1,2 @@
+Slides for the the talks of the 2018 OME Users Meeting
+https://www.openmicroscopy.org/events/13th-annual-users-meeting-2018.html

--- a/2018/Users-Meeting/Workshops/readme.txt
+++ b/2018/Users-Meeting/Workshops/readme.txt
@@ -1,0 +1,2 @@
+Support material for the workshops of Day 2 of the 2018 OME Users Meeting
+https://www.openmicroscopy.org/events/13th-annual-users-meeting-2018.html


### PR DESCRIPTION
To be deployed on http://downloads.openmicroscopy.org/presentations/ via https://github.com/openmicroscopy/prod-playbooks/pull/63/files.

The new folders can later be cross-linked from https://www.openmicroscopy.org/events/13th-annual-users-meeting-2018.html