### PR TITLE
Binary Vessels - update link to use lower case

### DIFF
--- a/2018/Users-Meeting/Workshops/NewFileFormats/BinaryVessels/index.html
+++ b/2018/Users-Meeting/Workshops/NewFileFormats/BinaryVessels/index.html
@@ -173,7 +173,7 @@
                       </ul>
                   </div>
                   <div id="right_col_30">
-                      <img width="100%" height="100%" src="images/currentModel.png"/>
+                      <img width="100%" height="100%" src="images/currentmodel.png"/>
                   </div>
                 </section>
                 


### PR DESCRIPTION
Update to fix broken link - http://downloads.openmicroscopy.org/presentations/2018/Users-Meeting/Workshops/NewFileFormats/BinaryVessels/images/currentModel.png